### PR TITLE
Change ‘\’ syntax to punctuation

### DIFF
--- a/vdf-mode.el
+++ b/vdf-mode.el
@@ -33,6 +33,7 @@
     (modify-syntax-entry ?\n "> b" syntax-table)
     (modify-syntax-entry ?{ "(}" syntax-table)
     (modify-syntax-entry ?} "){" syntax-table)
+    (modify-syntax-entry ?\\ "." syntax-table)
     syntax-table) "Syntax table for `vdf-mode'.")
 
 (defvar vdf-highlights


### PR DESCRIPTION
As far as I can tell a ‘\’ in vdf files isn’t an escape character.

I was working on some vdf files and noticed that syntax highlighting broke when I had paths that ended in `\`. This change fixed that.