### PR TITLE
Define ‘comment-start-skip’

### DIFF
--- a/vdf-mode.el
+++ b/vdf-mode.el
@@ -66,6 +66,7 @@
   (set (make-local-variable 'font-lock-defaults) '(vdf-highlights))
   (set-syntax-table vdf-mode-syntax-table)
   (setq-local comment-start "// ")
+  (setq-local comment-start-skip "// *")
   (setq-local comment-end "")
   (set (make-local-variable 'indent-line-function) 'vdf-indent-line))
 


### PR DESCRIPTION
This fixes highlighting of the comment start with the ‘font-lock-comment-delimiter-face’ and fixes at least the use of the ‘comment-search-forward’ function.